### PR TITLE
Add ALIGN_KEY_VALUE_PAIRS

### DIFF
--- a/codestyles/Keboola CS.xml
+++ b/codestyles/Keboola CS.xml
@@ -13,6 +13,7 @@
     <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
     <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="0" />
     <option name="FORCE_SHORT_DECLARATION_ARRAY_STYLE" value="true" />
+    <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
   </PHPCodeStyleSettings>
   <SqlCodeStyleSettings version="1">
     <option name="myVersion" value="1" />


### PR DESCRIPTION
Není to zarovnané lepší?

```
            [
                "aaaaaa" => 0,
                "b" => 1,
                "cccccccccc" => 2,
            ]
VS
            [
                "aaaaaa"     => 0,
                "b"          => 1,
                "cccccccccc" => 2,
            ]
```